### PR TITLE
Visually display test error in MazeSolver.ts

### DIFF
--- a/src/__tests__/MazeSolver.ts
+++ b/src/__tests__/MazeSolver.ts
@@ -10,23 +10,36 @@ test("maze solver", function () {
         "x xxxxxxxxxx",
     ];
 
+    const mazeResult = [
+        { x: 10, y: 0 },
+        { x: 10, y: 1 },
+        { x: 10, y: 2 },
+        { x: 10, y: 3 },
+        { x: 10, y: 4 },
+        { x: 9, y: 4 },
+        { x: 8, y: 4 },
+        { x: 7, y: 4 },
+        { x: 6, y: 4 },
+        { x: 5, y: 4 },
+        { x: 4, y: 4 },
+        { x: 3, y: 4 },
+        { x: 2, y: 4 },
+        { x: 1, y: 4 },
+        { x: 1, y: 5 },
+    ];
+
     // there is only one path through
-    expect(maze_solver(maze, "x", {x: 10, y: 0}, {x: 1, y: 5})).toEqual([
-        {x: 10, y: 0},
-        {x: 10, y: 1},
-        {x: 10, y: 2},
-        {x: 10, y: 3},
-        {x: 10, y: 4},
-        {x: 9, y: 4},
-        {x: 8, y: 4},
-        {x: 7, y: 4},
-        {x: 6, y: 4},
-        {x: 5, y: 4},
-        {x: 4, y: 4},
-        {x: 3, y: 4},
-        {x: 2, y: 4},
-        {x: 1, y: 4},
-        {x: 1, y: 5},
-    ]);
+    const result = maze_solver(maze, "x", { x: 10, y: 0 }, { x: 1, y: 5 });
+    expect(drawPath(maze, result)).toEqual(drawPath(maze, mazeResult));
 });
+
+function drawPath(data: string[], path: Point[]) {
+    const data2 = data.map((row) => row.split(''));
+    path.forEach((p) => {
+        if (data2[p.y] && data2[p.y][p.x]) {
+            data2[p.y][p.x] = '*';
+        }
+    });
+    return data2.map(d => d.join(''));
+}
 


### PR DESCRIPTION
This will visually show Maze error by highlighting the path
![Screenshot from 2022-09-16 15-00-11](https://user-images.githubusercontent.com/2401271/190645475-bb35d946-e741-46ea-b2b2-74d5d13283c1.png)
