### PR TITLE
Update generate and clear scripts in package.json to fix Issue#10 - generate from scripts is not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     "scripts": {
         "test": "jest DFSOnBST LRU LinearSearchList BinarySearchList TwoCrystalBalls BubbleSort DoublyLinkedList Queue Stack ArrayList MazeSolver QuickSort BTPreOrder BTInOrder BTPostOrder BTBFS CompareBinaryTrees DFSOnBST DFSGraphList Trie BFSGraphMatrix Map MinHeap",
-        "clear": "./scripts/clear",
+        "clear": "node ./scripts/clear",
         "prettier": "prettier --write ./src",
-        "generate": "./scripts/generate",
-        "day": "echo /home/mpaulson/personal/kata-machine/src/day2"
+        "generate": "node ./scripts/generate",
+        "day": "echo C:\\Users\\bruce\\learning\\kata-machine\\src\\day1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     "scripts": {
         "test": "jest DFSOnBST LRU LinearSearchList BinarySearchList TwoCrystalBalls BubbleSort DoublyLinkedList Queue Stack ArrayList MazeSolver QuickSort BTPreOrder BTInOrder BTPostOrder BTBFS CompareBinaryTrees DFSOnBST DFSGraphList Trie BFSGraphMatrix Map MinHeap",
-        "clear": "node ./scripts/clear",
+        "clear": "node ./scripts/clear.js",
         "prettier": "prettier --write ./src",
-        "generate": "node ./scripts/generate",
+        "generate": "node ./scripts/generate.js",
         "day": "echo C:\\Users\\bruce\\learning\\kata-machine\\src\\day1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
         "clear": "node ./scripts/clear.js",
         "prettier": "prettier --write ./src",
         "generate": "node ./scripts/generate.js",
-        "day": "echo C:\\Users\\bruce\\learning\\kata-machine\\src\\day1"
+        "day": "echo src\\day2"
     }
 }

--- a/scripts/clear.js
+++ b/scripts/clear.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
 

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
 const config = require("../ligma.config");

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -23,6 +23,7 @@ try {
 
 const day_name = `day${day}`;
 const day_path = path.join(src_path, day_name);
+const relative_day_path = path.relative(process.cwd(), day_path);
 try { fs.unlinkSync(day_path); } catch (e) { }
 try { fs.mkdirSync(day_path); } catch (e) { }
 
@@ -77,6 +78,6 @@ config.dsa.forEach(ds => {
 const align = require("./align-configs");
 align.jest(day_name);
 align.ts_config(day_name);
-align.package_json(config, day_path);
+align.package_json(config, relative_day_path);
 align.stats(config, day_path);
 


### PR DESCRIPTION
**Changes made to fix** <a href="https://github.com/ThePrimeagen/kata-machine/issues/10">Issue#10</a>

- Removed `shebang`  in `generate` and `clear` scripts
- Added `.js` extension to `generate` and `clear` script files
- Updated the `generate` and `clear` scripts in package.json to use node instead of running directly as if they were in binary

<br>

**About the approach**

Running the scripts using node directly and removing shebang is the simplest way of solving the issue, as shebag is not supported on windows systems, this approach uses the normal `node` command to interpret the file which is supported on all the operating systems