### PR TITLE
add: twocrystalball - case of perfect sqrts

### DIFF
--- a/src/__tests__/TwoCrystalBalls.ts
+++ b/src/__tests__/TwoCrystalBalls.ts
@@ -10,5 +10,17 @@ test("two crystal balls", function () {
 
     expect(two_crystal_balls(data)).toEqual(idx);
     expect(two_crystal_balls(new Array(821).fill(false))).toEqual(-1);
+
+    // for testing exact sqrts
+    let sqrti = Math.floor(Math.random() * 100);
+    let dataSize = sqrti * sqrti;
+    const sqrtsData = new Array(dataSize).fill(false);
+    
+    for(let i = sqrti; i < dataSize; i++) {
+        sqrtsData[i] = true;
+    }
+
+    expect(two_crystal_balls(sqrtsData)).toEqual(sqrti);
+
 });
 


### PR DESCRIPTION
algo shown in FEM - twocrystalballs misses a case where index of first `true` is perfect sqrt-factor of arr size (arr must be perfect sq size)

adding test case to check for such instance

example:

```
arr = [ F, F, F, F, F, F, F, F, T, T, T, T, T, T, T ,T]
// size = 16
// jmp = 4
// ix = 9
```

in the above example, `return = -1` based on the algo shown on FEM

error due to classic case of exclusion of the index where `true` is found in the **first** `for` loop (first ball smash)
