### PR TITLE
test: Expand Trie.ts coverage

### DIFF
--- a/src/__tests__/Trie.ts
+++ b/src/__tests__/Trie.ts
@@ -20,7 +20,7 @@ test("Trie", function() {
         "foolish",
     ]);
     
-	trie.delete("foolish");
+    trie.delete("foolish");
 
     expect(trie.find("fo").sort()).toEqual([
         "foo"

--- a/src/__tests__/Trie.ts
+++ b/src/__tests__/Trie.ts
@@ -19,5 +19,11 @@ test("Trie", function() {
         "foo",
         "foolish",
     ]);
+    
+	trie.delete("foolish");
+
+    expect(trie.find("fo").sort()).toEqual([
+        "foo"
+    ]);
 });
 


### PR DESCRIPTION
I created a Trie that passes the tests, but when I delete a word that forms an entire branch (where the last node is a leaf), it starts deleting nodes with only one child until it finds a node with more children, instead of stopping when it reaches a node indicating the end of a word.