### PR TITLE
Fix import on Prims algorithm test

### DIFF
--- a/src/__tests__/PrimsList.ts
+++ b/src/__tests__/PrimsList.ts
@@ -1,4 +1,4 @@
-import prims from "@code/PrimsAlgorithm";
+import prims from "@code/PrimsList";
 import { list1 } from "./graph";
 
 test("PrimsAlgorithm", function () {


### PR DESCRIPTION
I had an error while trying to run the Prims Test and it was because of the import, the file is called PrimsList and the test was trying to import a file called PrimsAlgorithm.