### PR TITLE
02 stack and queue

### DIFF
--- a/.jest.config.json
+++ b/.jest.config.json
@@ -2,7 +2,7 @@
     "clearMocks": true,
     "moduleNameMapper": {
         "@code/(.*)": [
-            "<rootDir>/src/day2/$1"
+            "<rootDir>/src/day1/$1"
         ]
     },
     "preset": "ts-jest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,7 +1005,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1022,7 +1021,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1039,7 +1037,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1056,7 +1053,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1073,7 +1069,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1090,7 +1085,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1107,7 +1101,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1124,7 +1117,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1141,7 +1133,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1158,7 +1149,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
         "typescript": "^4.7.4"
     },
     "scripts": {
-        "test": "jest PrimsList",
+        "test": "jest DFSOnBST LRU LinearSearchList BinarySearchList TwoCrystalBalls BubbleSort SinglyLinkedList DoublyLinkedList Queue Stack ArrayList MazeSolver QuickSort BTPreOrder BTInOrder BTPostOrder BTBFS CompareBinaryTrees DFSOnBST DFSGraphList Trie BFSGraphMatrix Map MinHeap",
         "clear": "node ./scripts/clear.js",
         "prettier": "prettier --write ./src",
         "generate": "node ./scripts/generate.js",
-        "day": "echo src/day4"
+        "day": "echo src/day1"
     },
     "devDependencies": {
         "@swc-node/register": "^1.6.7"

--- a/src/day1/ArrayList.ts
+++ b/src/day1/ArrayList.ts
@@ -1,0 +1,27 @@
+export default class ArrayList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/BFSGraphMatrix.ts
+++ b/src/day1/BFSGraphMatrix.ts
@@ -1,0 +1,3 @@
+export default function bfs(graph: WeightedAdjacencyMatrix, source: number, needle: number): number[] | null {
+
+}

--- a/src/day1/BTBFS.ts
+++ b/src/day1/BTBFS.ts
@@ -1,0 +1,3 @@
+export default function bfs(head: BinaryNode<number>, needle: number): boolean {
+
+}

--- a/src/day1/BTInOrder.ts
+++ b/src/day1/BTInOrder.ts
@@ -1,0 +1,3 @@
+export default function in_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BTPostOrder.ts
+++ b/src/day1/BTPostOrder.ts
@@ -1,0 +1,3 @@
+export default function post_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BTPreOrder.ts
+++ b/src/day1/BTPreOrder.ts
@@ -1,0 +1,3 @@
+export default function pre_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BinarySearchList.ts
+++ b/src/day1/BinarySearchList.ts
@@ -1,0 +1,3 @@
+export default function bs_list(haystack: number[], needle: number): boolean {
+
+}

--- a/src/day1/BinarySearchList.ts
+++ b/src/day1/BinarySearchList.ts
@@ -1,3 +1,22 @@
 export default function bs_list(haystack: number[], needle: number): boolean {
+    let lo = 0;
+    let hi = haystack.length;
 
+    do {
+        const mid = Math.floor(lo + (hi - lo)/ 2);
+        const value = haystack[mid];
+
+        if (value === needle) {
+            return true;
+        }
+
+        if (value > needle) {
+            hi = mid; 
+        } else {
+            lo = mid + 1;
+        }
+
+    } while (lo < hi);
+
+    return false;
 }

--- a/src/day1/BubbleSort.ts
+++ b/src/day1/BubbleSort.ts
@@ -1,0 +1,3 @@
+export default function bubble_sort(arr: number[]): void {
+
+}

--- a/src/day1/BubbleSort.ts
+++ b/src/day1/BubbleSort.ts
@@ -1,3 +1,9 @@
 export default function bubble_sort(arr: number[]): void {
-
+    for (let i = 0; i < arr.length; ++i) {
+        for (let j = 0; j < arr.length - 1 - i; ++j) {
+            if (arr[j] > arr[j + 1]) {
+                [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
+            }
+        }
+    }
 }

--- a/src/day1/CompareBinaryTrees.ts
+++ b/src/day1/CompareBinaryTrees.ts
@@ -1,0 +1,3 @@
+export default function compare(a: BinaryNode<number> | null, b: BinaryNode<number> | null): boolean {
+
+}

--- a/src/day1/DFSGraphList.ts
+++ b/src/day1/DFSGraphList.ts
@@ -1,0 +1,3 @@
+export default function dfs(graph: WeightedAdjacencyList, source: number, needle: number): number[] | null {
+
+}

--- a/src/day1/DFSOnBST.ts
+++ b/src/day1/DFSOnBST.ts
@@ -1,0 +1,3 @@
+export default function dfs(head: BinaryNode<number>, needle: number): boolean {
+
+}

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -1,0 +1,27 @@
+export default class DoublyLinkedList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/LRU.ts
+++ b/src/day1/LRU.ts
@@ -1,0 +1,15 @@
+export default class LRU<K, V> {
+    private length: number;
+
+    
+
+    constructor() {
+    }
+
+    update(key: K, value: V): void {
+
+}
+    get(key: K): V | undefined {
+
+}
+}

--- a/src/day1/LinearSearchList.ts
+++ b/src/day1/LinearSearchList.ts
@@ -1,0 +1,9 @@
+export default function linear_search(haystack: number[], needle: number): boolean {
+    for (let i = 0; i < haystack.length; i++) {
+        if (haystack[i] === needle) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/day1/Map.ts
+++ b/src/day1/Map.ts
@@ -1,0 +1,21 @@
+export default class Map<T extends (string | number), V> {
+    
+
+    
+
+    constructor() {
+    }
+
+    get(key: T): V | undefined {
+
+}
+    set(key: T, value: V): void {
+
+}
+    delete(key: T): V | undefined {
+
+}
+    size(): number {
+
+}
+}

--- a/src/day1/MazeSolver.ts
+++ b/src/day1/MazeSolver.ts
@@ -1,0 +1,3 @@
+export default function solve(maze: string[], wall: string, start: Point, end: Point): Point[] {
+
+}

--- a/src/day1/MinHeap.ts
+++ b/src/day1/MinHeap.ts
@@ -1,0 +1,15 @@
+export default class MinHeap {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    insert(value: number): void {
+
+}
+    delete(): number {
+
+}
+}

--- a/src/day1/Queue.ts
+++ b/src/day1/Queue.ts
@@ -1,0 +1,18 @@
+export default class Queue<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    enqueue(item: T): void {
+
+}
+    deque(): T | undefined {
+
+}
+    peek(): T | undefined {
+
+}
+}

--- a/src/day1/Queue.ts
+++ b/src/day1/Queue.ts
@@ -1,18 +1,52 @@
+type Node<T> = {
+    value: T;
+    next?: Node<T>;
+};
+
 export default class Queue<T> {
     public length: number;
-
-    
+    private head?: Node<T>;
+    private tail?: Node<T>;
 
     constructor() {
+        this.head = undefined;
+        this.tail = undefined;
+        this.length = 0;
     }
 
     enqueue(item: T): void {
+        const node = { value: item } as Node<T>
 
-}
+        if (!this.tail) {
+            this.length++;
+            this.head = node;
+            this.tail = node;
+            return; 
+        }
+
+        this.length++;
+
+        if (!this.head) {
+            this.head = node;
+            this.head.next = node;
+        }
+
+        this.tail.next = node;
+        this.tail = node;
+    }   
+
     deque(): T | undefined {
+        if (!this?.head) return undefined;
 
-}
+        this.length--;
+
+        const head = this.head;
+        this.head = this.head.next;
+
+        return head?.value;
+    }
+
     peek(): T | undefined {
-
-}
+        return this?.head?.value;
+    }
 }

--- a/src/day1/QuickSort.ts
+++ b/src/day1/QuickSort.ts
@@ -1,0 +1,3 @@
+export default function quick_sort(arr: number[]): void {
+
+}

--- a/src/day1/SinglyLinkedList.ts
+++ b/src/day1/SinglyLinkedList.ts
@@ -1,0 +1,27 @@
+export default class SinglyLinkedList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/Stack.ts
+++ b/src/day1/Stack.ts
@@ -1,0 +1,18 @@
+export default class Stack<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    push(item: T): void {
+
+}
+    pop(): T | undefined {
+
+}
+    peek(): T | undefined {
+
+}
+}

--- a/src/day1/Stack.ts
+++ b/src/day1/Stack.ts
@@ -1,18 +1,48 @@
+type Node<T> = {
+    value: T;
+    prev: Node<T>;
+}
+
 export default class Stack<T> {
     public length: number;
-
+    private head?: Node<T>;
     
-
     constructor() {
+        this.head = undefined;
+        this.length = 0;
     }
 
     push(item: T): void {
+        const node = { value: item } as Node<T>;
+        
+        this.length++;
 
-}
+        if (!this.head) {
+            this.head = node;
+            return;
+        }
+
+        node.prev = this.head;
+        this.head = node;
+    }
+
     pop(): T | undefined {
+        const head = this.head as Node<T>;
 
-}
+        const length = Math.max(0, this.length - 1);
+
+        if (length === 0) {
+            this.head = undefined;
+            return head?.value;
+        }
+
+        this.head = head?.prev;
+        this.length--;
+
+        return head.value;
+    }
+
     peek(): T | undefined {
-
-}
+        return this.head?.value;
+    }
 }

--- a/src/day1/Trie.ts
+++ b/src/day1/Trie.ts
@@ -1,0 +1,18 @@
+export default class Trie {
+    
+
+    
+
+    constructor() {
+    }
+
+    insert(item: string): void {
+
+}
+    delete(item: string): void {
+
+}
+    find(partial: string): string[] {
+
+}
+}

--- a/src/day1/TwoCrystalBalls.ts
+++ b/src/day1/TwoCrystalBalls.ts
@@ -1,0 +1,3 @@
+export default function two_crystal_balls(breaks: boolean[]): number {
+
+}

--- a/src/day1/TwoCrystalBalls.ts
+++ b/src/day1/TwoCrystalBalls.ts
@@ -1,3 +1,22 @@
 export default function two_crystal_balls(breaks: boolean[]): number {
 
+    const jumpAmount = Math.floor(Math.sqrt(breaks.length));
+
+    let i = jumpAmount;
+
+    for(; i < breaks.length; i += jumpAmount) {
+        if (breaks[i]) {
+            break;
+        }
+    }
+
+    i -= jumpAmount;
+
+    for (let j = 0; j < jumpAmount && i < breaks.length; ++j, ++i) {
+        if (breaks[i]) {
+            return i;
+        }
+    }
+
+    return -1;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "baseUrl": "src",
         "paths": {
             "@code/*": [
-                "day4/*"
+                "day1/*"
             ]
         }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,15 +592,10 @@
     source-map-support "^0.5.21"
     tslib "^2.5.0"
 
-"@swc/core-linux-x64-gnu@1.3.80":
+"@swc/core-darwin-arm64@1.3.80":
   version "1.3.80"
-  resolved "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.80.tgz"
-  integrity sha512-+2e5oni1vOrLIjM5Q2/GIzK/uS2YEtuJqnjPvCK8SciRJsSl8OgVsRvyCDbmKeZNtJ2Q+o/O2AQ2w1qpAJG6jg==
-
-"@swc/core-linux-x64-musl@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.80.tgz"
-  integrity sha512-8OK9IlI1zpWOm7vIp1iXmZSEzLAwFpqhsGSEhxPavpOx2m54kLFdPcw/Uv3n461f6TCtszIxkGq1kSqBUdfUBA==
+  resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.80.tgz"
+  integrity sha512-rhoFTcQMUGfO7IkfOnopPSF6O0/aVJ58B7KueIKbvrMe6YvSfFj9QfObELFjYCcrJZTvUWBhig0QrsfPIiUphA==
 
 "@swc/core@>= 1.3", "@swc/core@>=1.2.50":
   version "1.3.80"
@@ -1171,6 +1166,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly adds new algorithm/data-structure modules and rewires Jest/TS path aliases to `day1`, with moderate risk of breaking imports/tests due to the alias and script changes; many new modules are still unimplemented stubs.
> 
> **Overview**
> Switches the `@code/*` alias and Jest module mapping from later-day folders to `src/day1`, and updates `npm test`/`day` scripts to run a broad suite of day1 kata tests.
> 
> Adds a new `src/day1` set of algorithms/data structures: implemented `linear_search`, `bs_list`, `bubble_sort`, and `two_crystal_balls`, plus initial `Queue` and `Stack` implementations; most other additions (e.g., lists, LRU, trie, heaps, graph/tree traversals, maze solver, quicksort) are currently skeletons with empty method bodies.
> 
> Updates lockfiles with minor SWC optional-dependency metadata changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 174634eeec755ae17e8613dda389532b1e854736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->