### PR TITLE
Day 1 (aka Prime's answers in the speedrun)

### DIFF
--- a/.jest.config.json
+++ b/.jest.config.json
@@ -2,7 +2,7 @@
     "clearMocks": true,
     "moduleNameMapper": {
         "@code/(.*)": [
-            "<rootDir>/src/day2/$1"
+            "<rootDir>/src/day1/$1"
         ]
     },
     "preset": "ts-jest"

--- a/ligma.config.js
+++ b/ligma.config.js
@@ -1,5 +1,9 @@
 module.exports = {
     dsa: [
+        "InsertionSort",
+        "MergeSort",
+        "DijkstraList",
+        "PrimsList",
         "DFSOnBST",
         "LRU",
         "LinearSearchList",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
         "typescript": "^4.7.4"
     },
     "scripts": {
-        "test": "jest PrimsList",
+        "test": "jest InsertionSort MergeSort DijkstraList PrimsList DFSOnBST LRU LinearSearchList BinarySearchList TwoCrystalBalls BubbleSort SinglyLinkedList DoublyLinkedList Queue Stack ArrayList MazeSolver QuickSort BTPreOrder BTInOrder BTPostOrder BTBFS CompareBinaryTrees DFSOnBST DFSGraphList Trie BFSGraphMatrix Map MinHeap",
         "clear": "node ./scripts/clear.js",
         "prettier": "prettier --write ./src",
         "generate": "node ./scripts/generate.js",
-        "day": "echo src/day4"
+        "day": "echo src\\day1"
     },
     "devDependencies": {
         "@swc-node/register": "^1.6.7"

--- a/src/day1/ArrayList.ts
+++ b/src/day1/ArrayList.ts
@@ -1,0 +1,27 @@
+export default class ArrayList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/BFSGraphMatrix.ts
+++ b/src/day1/BFSGraphMatrix.ts
@@ -1,0 +1,3 @@
+export default function bfs(graph: WeightedAdjacencyMatrix, source: number, needle: number): number[] | null {
+
+}

--- a/src/day1/BFSGraphMatrix.ts
+++ b/src/day1/BFSGraphMatrix.ts
@@ -1,3 +1,51 @@
-export default function bfs(graph: WeightedAdjacencyMatrix, source: number, needle: number): number[] | null {
+export default function bfs(
+  graph: WeightedAdjacencyMatrix, 
+  source: number, 
+  needle: number): number[] | null {
 
+    const seen = new Array(graph.length).fill(false);
+    const prev = new Array(graph.length).fill(-1);
+
+    seen[source] = true;
+    const q: number[] = [source];
+
+    do {
+        const curr = q.shift() as number;
+        if (curr === needle) {
+          break;
+        }
+
+        const adjs = graph[curr];
+        for (let i = 0; i < graph.length; i++) {
+          if (adjs[i] === 0) {
+            continue;
+          }
+
+          if (seen[i]) {
+            continue;
+          }
+
+          seen[i] = true;
+          prev[i] = curr;
+          q.push(i);
+        }
+        seen[curr] = true;
+
+    } while (q.length);
+
+    // build it backwards
+    let curr = needle;
+    const out: number[] = [];
+
+    while (prev[curr] !== -1) {
+      out.push(curr);
+      curr = prev[curr];
+    }
+
+    if (out.length) {
+      return [source].concat(out.reverse()); // re-add the source as it doesn't have a parent and won't be added  in as part of the walkback
+    }
+
+    return null;
+    
 }

--- a/src/day1/BTBFS.ts
+++ b/src/day1/BTBFS.ts
@@ -1,0 +1,3 @@
+export default function bfs(head: BinaryNode<number>, needle: number): boolean {
+
+}

--- a/src/day1/BTBFS.ts
+++ b/src/day1/BTBFS.ts
@@ -1,3 +1,24 @@
 export default function bfs(head: BinaryNode<number>, needle: number): boolean {
+  const q: (BinaryNode<number> | null)[] = [head];
 
+  while (q.length) {
+    const curr = q.shift() as BinaryNode<number>;
+    if (!curr) {
+      continue;
+    }
+
+    // Search
+    if (curr?.value === needle) {
+      return true;
+    }
+
+    if (curr.left) {
+      q.push(curr.left);
+    }
+    if (curr.right) {
+      q.push(curr.right);
+    }
+  }
+
+  return false;
 }

--- a/src/day1/BTInOrder.ts
+++ b/src/day1/BTInOrder.ts
@@ -1,0 +1,3 @@
+export default function in_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BTInOrder.ts
+++ b/src/day1/BTInOrder.ts
@@ -1,3 +1,21 @@
-export default function in_order_search(head: BinaryNode<number>): number[] {
+function walk(curr: BinaryNode<number> | null, path: number[]): number[] {
+  // Base case - hit a leaf
+  if (!curr) {
+    return path;
+  }
 
+  // recurse:
+  // pre
+  
+  // recurse
+  walk(curr.left, path);
+  path.push(curr.value);
+  walk(curr.right, path);
+
+  // post
+  return path;
+}
+
+export default function in_order_search(head: BinaryNode<number>): number[] {
+  return walk(head, []);
 }

--- a/src/day1/BTPostOrder.ts
+++ b/src/day1/BTPostOrder.ts
@@ -1,0 +1,3 @@
+export default function post_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BTPostOrder.ts
+++ b/src/day1/BTPostOrder.ts
@@ -1,3 +1,21 @@
-export default function post_order_search(head: BinaryNode<number>): number[] {
+function walk(curr: BinaryNode<number> | null, path: number[]): number[] {
+  // Base case - hit a leaf
+  if (!curr) {
+    return path;
+  }
 
+  // recurse:
+  // pre
+  
+  // recurse
+  walk(curr.left, path);
+  walk(curr.right, path);
+  
+  // post
+  path.push(curr.value);
+  return path;
+}
+
+export default function post_order_search(head: BinaryNode<number>): number[] {
+  return walk(head, []);
 }

--- a/src/day1/BTPreOrder.ts
+++ b/src/day1/BTPreOrder.ts
@@ -1,0 +1,3 @@
+export default function pre_order_search(head: BinaryNode<number>): number[] {
+
+}

--- a/src/day1/BTPreOrder.ts
+++ b/src/day1/BTPreOrder.ts
@@ -1,3 +1,22 @@
-export default function pre_order_search(head: BinaryNode<number>): number[] {
+function walk(curr: BinaryNode<number> | null, path: number[]): number[] {
+  // Base case - hit a leaf
+  if (!curr) {
+    return path;
+  }
 
+  // recurse:
+  // pre
+  path.push(curr.value);
+  
+  // recurse
+  walk(curr.left, path);
+  walk(curr.right, path);
+
+  // post
+  return path;
+}
+
+
+export default function pre_order_search(head: BinaryNode<number>): number[] {
+  return walk(head, []);
 }

--- a/src/day1/BinarySearchList.ts
+++ b/src/day1/BinarySearchList.ts
@@ -1,0 +1,3 @@
+export default function bs_list(haystack: number[], needle: number): boolean {
+
+}

--- a/src/day1/BinarySearchList.ts
+++ b/src/day1/BinarySearchList.ts
@@ -1,3 +1,18 @@
 export default function bs_list(haystack: number[], needle: number): boolean {
+  let low = 0;
+  let high = haystack.length;
+  
+  while (low < high) {
+    const mid = Math.floor(low + (high - low) / 2);
+    const v = haystack[mid];
 
+    if (v === needle) {
+      return true;
+    } else if (v > needle) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return false;
 }

--- a/src/day1/BubbleSort.ts
+++ b/src/day1/BubbleSort.ts
@@ -1,0 +1,3 @@
+export default function bubble_sort(arr: number[]): void {
+
+}

--- a/src/day1/BubbleSort.ts
+++ b/src/day1/BubbleSort.ts
@@ -1,3 +1,25 @@
 export default function bubble_sort(arr: number[]): void {
+  // let end: number = arr.length - 2;
+  // let current: number;
+  
+  // while (end > 0) {
+  //   for (let i = 0; i < end; i++) {
+  //     current = arr[i];
+  //     if (arr[i] > arr[i + 1]) {
+  //       arr[i] = arr[i + 1];
+  //       arr[i + 1] = current;
+  //     }
+  //     end --;
+  //   }
+  // }
 
+  for (let i = 0; i < arr.length; i++) {
+    for (let j = 0; j < arr.length - 1 - i; j++) {
+      if (arr[j] > arr[j + 1]) {
+        const tmp = arr[j];
+        arr[j] = arr[j + 1];
+        arr[j + 1] = tmp;        
+      }
+    }
+  }
 }

--- a/src/day1/CompareBinaryTrees.ts
+++ b/src/day1/CompareBinaryTrees.ts
@@ -1,0 +1,3 @@
+export default function compare(a: BinaryNode<number> | null, b: BinaryNode<number> | null): boolean {
+
+}

--- a/src/day1/CompareBinaryTrees.ts
+++ b/src/day1/CompareBinaryTrees.ts
@@ -1,3 +1,22 @@
 export default function compare(a: BinaryNode<number> | null, b: BinaryNode<number> | null): boolean {
 
+  // Base case 1
+  // (structural check)
+  if (a === null && b === null) {
+    return true;
+  }
+
+  // Base case 2
+  // (structural check)
+  if (a === null || b === null) {
+    return false;
+  }
+
+  // Base case 3
+  // (value check)
+  if (a.value !== b.value) {
+    return false;
+  }
+
+  return compare(a.left, b.left) && compare(a.right, b.right);
 }

--- a/src/day1/DFSGraphList.ts
+++ b/src/day1/DFSGraphList.ts
@@ -1,0 +1,3 @@
+export default function dfs(graph: WeightedAdjacencyList, source: number, needle: number): number[] | null {
+
+}

--- a/src/day1/DFSGraphList.ts
+++ b/src/day1/DFSGraphList.ts
@@ -1,3 +1,49 @@
-export default function dfs(graph: WeightedAdjacencyList, source: number, needle: number): number[] | null {
+function walk(graph: WeightedAdjacencyList, 
+  curr: number, 
+  needle: number, 
+  seen: boolean[], 
+  path: number[]): boolean {
+    if (seen[curr]) {
+      return false;
+    }
 
+    seen[curr] = true;
+
+    // recurse
+    //pre
+    path.push(curr);    
+    if (curr === needle) {
+      return true;
+    }
+    
+    //recurse
+    const list = graph[curr];
+    for (let i = 0; i < list.length; i++) {
+      const edge = list[i];
+
+      if (walk(graph, edge.to, needle, seen, path)) {
+        return true;
+      }
+    }
+        
+    //post
+    path.pop();
+
+    return false;
+  }
+
+export default function dfs(
+  graph: WeightedAdjacencyList, 
+  source: number, 
+  needle: number): number[] | null {
+    const seen: boolean[] = new Array(graph.length).fill(false);
+    const path: number[] = [];
+
+    walk(graph, source, needle, seen, path);
+
+    if (path.length === 0) {
+      return null;
+    }
+
+    return path;
 }

--- a/src/day1/DFSOnBST.ts
+++ b/src/day1/DFSOnBST.ts
@@ -1,0 +1,3 @@
+export default function dfs(head: BinaryNode<number>, needle: number): boolean {
+
+}

--- a/src/day1/DFSOnBST.ts
+++ b/src/day1/DFSOnBST.ts
@@ -1,3 +1,19 @@
-export default function dfs(head: BinaryNode<number>, needle: number): boolean {
+function search(curr:BinaryNode<number> | null, needle: number): boolean {
+  if (!curr) {
+    return false;
+  }
 
+  if (curr.value === needle) {
+    return true;
+  }
+
+  if (curr.value < needle) {
+    return search(curr.right, needle);
+  }
+
+  return search(curr.left, needle);
+}
+
+export default function dfs(head: BinaryNode<number>, needle: number): boolean {
+  return search(head, needle);
 }

--- a/src/day1/DijkstraList.ts
+++ b/src/day1/DijkstraList.ts
@@ -1,0 +1,3 @@
+export default function dijkstra_list(source: number, sink: number, arr: WeightedAdjacencyList): number[] {
+
+}

--- a/src/day1/DijkstraList.ts
+++ b/src/day1/DijkstraList.ts
@@ -1,3 +1,61 @@
-export default function dijkstra_list(source: number, sink: number, arr: WeightedAdjacencyList): number[] {
+function hasUnvisited(seen: boolean[], dists: number[]): boolean {
+  return seen.some((s, i) => !s && dists[i] < Infinity);
+}
 
+function getLowestUnvisited(seen: boolean[], dists: number[]): number {
+  let idx = -1;
+  let lowestDistance = Infinity;
+
+  for (let i = 0; i < seen.length; i++) {
+    if (seen[i]) {
+      continue;
+    }
+
+    if (lowestDistance > dists[i]) {
+      lowestDistance = dists[i];
+      idx = i;
+    }
+  }
+
+  return idx;
+}
+
+export default function dijkstra_list(source: number, 
+  sink: number, 
+  arr: WeightedAdjacencyList): number[] {    
+
+    const seen = new Array(arr.length).fill(false);
+    const prev = new Array(arr.length).fill(-1);
+    const dists = new Array(arr.length).fill(Infinity);
+    dists[source] = 0;
+    
+    while (hasUnvisited(seen, dists)) {
+      const curr = getLowestUnvisited(seen, dists);
+      seen[curr] = true;
+
+      const adjs = arr[curr];
+      for (let i = 0; i < adjs.length; i++) {
+        const edge = adjs[i];
+        if (seen[edge.to]) {
+          continue;
+        }
+
+        const dist = dists[curr] + edge.weight;
+        if (dist < dists[edge.to]) {
+          dists[edge.to] = dist;
+          prev[edge.to] = curr;
+        }
+      }
+    }
+
+    const out: number[] = [];
+    let curr = sink;
+
+    while (prev[curr] !== -1) {
+      out.push(curr);
+      curr = prev[curr];
+    }
+
+    out.push(source); // cos source isn't added in the backwalk as it has no parent(s)
+    return out.reverse(); // cos walkback is walking back
 }

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -1,0 +1,27 @@
+export default class DoublyLinkedList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -1,27 +1,88 @@
+type Node<T> = {
+    value: T,
+    prev?: Node<T>,
+    next?: Node<T>,
+}
+
 export default class DoublyLinkedList<T> {
     public length: number;
-
-    
+    private head?: Node<T>;
+    private tail?: Node<T>;    
 
     constructor() {
+        this.length = 0;
+        this.head = undefined;
+        this.tail = undefined;
     }
 
     prepend(item: T): void {
+        const node = {value: item} as Node<T>;
 
-}
+        this.length++;
+        if (!this.head) {
+            this.head = this.tail = node;
+            return;
+        }
+
+        node.next = this.head;
+        this.head.prev = node;
+        this.head = node;
+    }
+
     insertAt(item: T, idx: number): void {
+        if (idx > this.length) {
+            throw new Error("too long johnny, index no exist");
+        }
 
-}
+        this.length++;
+        if (idx === this.length) {
+            this.append(item);
+            return;
+        } else if (idx === 0) {
+            this.prepend(item);
+            return;
+        }
+
+        let curr = this.head;
+        for (let i = 0; curr && i < idx; i++) {
+            curr = curr.next;
+        }
+
+        curr = curr as Node<T>;
+        const node = {value: item} as Node<T>;
+
+        node.next = curr;
+        node.prev = curr.prev;
+        curr.prev = node;
+
+        if (curr.prev) {
+            curr.prev.next = curr;
+        }
+    }
+
     append(item: T): void {
 
-}
+        this.length++;
+        const node = {value: item} as Node<T>;
+
+        if (!this.tail) {
+            this.head = this.tail = node;
+            return;
+        }
+
+        node.prev = this.tail;
+        this.tail.next = node;
+
+        this.tail = node;
+    }
+    
     remove(item: T): T | undefined {
 
-}
+    }
     get(idx: number): T | undefined {
 
-}
+    }
     removeAt(idx: number): T | undefined {
 
-}
+    }
 }

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -131,6 +131,5 @@ export default class DoublyLinkedList<T> {
             curr = curr.next;
         }
         return curr;
-
     }
 }

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -50,8 +50,8 @@ export default class DoublyLinkedList<T> {
         node.prev = curr.prev;
         curr.prev = node;
 
-        if (curr.prev) {
-            curr.prev.next = curr;
+        if (node.prev) {
+            node.prev.next = node
         }
     }
 

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -15,6 +15,16 @@ export default class DoublyLinkedList<T> {
         this.tail = undefined;
     }
 
+    private debug() {
+        let curr = this.head;
+        let out = "";
+        for (let i = 0; curr && i < this.length; i++) {
+            out += `${i} => ${curr.value} `;
+            curr = curr.next;
+        }
+        console.log(out);
+    }
+
     prepend(item: T): void {
         const node = {value: item} as Node<T>;
 
@@ -107,12 +117,12 @@ export default class DoublyLinkedList<T> {
             this.head = this.tail = undefined;
             return out;
         }
-
+        
         if (node.prev) {
-            node.prev = node.next;
+            node.prev.next = node.next;
         }        
         if (node.next) {
-            node.next = node.prev;
+            node.next.prev = node.prev;
         }
         
         if (node === this.head) {

--- a/src/day1/DoublyLinkedList.ts
+++ b/src/day1/DoublyLinkedList.ts
@@ -34,7 +34,6 @@ export default class DoublyLinkedList<T> {
             throw new Error("too long johnny, index no exist");
         }
 
-        this.length++;
         if (idx === this.length) {
             this.append(item);
             return;
@@ -42,13 +41,9 @@ export default class DoublyLinkedList<T> {
             this.prepend(item);
             return;
         }
-
-        let curr = this.head;
-        for (let i = 0; curr && i < idx; i++) {
-            curr = curr.next;
-        }
-
-        curr = curr as Node<T>;
+        
+        this.length++;
+        const curr = this.getAt(idx) as Node<T>;
         const node = {value: item} as Node<T>;
 
         node.next = curr;
@@ -61,7 +56,6 @@ export default class DoublyLinkedList<T> {
     }
 
     append(item: T): void {
-
         this.length++;
         const node = {value: item} as Node<T>;
 
@@ -75,14 +69,68 @@ export default class DoublyLinkedList<T> {
 
         this.tail = node;
     }
-    
+
     remove(item: T): T | undefined {
+        let curr = this.head;
+        for (let i = 0; curr && i < this.length; i++) {
+            if (curr.value !== item) {
+                break;
+            }
+            curr = curr.next;
+        }
+        if (!curr) {
+            return undefined;
+        }
 
+        return this.removeNode(curr);
     }
+
     get(idx: number): T | undefined {
-
+        return this.getAt(idx)?.value;
     }
+
     removeAt(idx: number): T | undefined {
+        const node = this.getAt(idx);
+
+        if (!node) {
+            return undefined;
+        }
+
+        return this.removeNode(node);
+    }
+
+    private removeNode(node: Node<T>): T | undefined {
+        this.length--;
+
+        if (this.length === 0) {
+            const out = this.head?.value;
+            this.head = this.tail = undefined;
+            return out;
+        }
+
+        if (node.prev) {
+            node.prev = node.next;
+        }        
+        if (node.next) {
+            node.next = node.prev;
+        }
+        
+        if (node === this.head) {
+            this.head = node.next;
+        }
+        if (node === this.tail) {
+            this.tail = node.prev;
+        }
+        
+        node.prev = node.next = undefined;
+        return node.value;
+    }
+    private getAt(idx: number): Node<T> | undefined {
+        let curr = this.head;
+        for (let i = 0; curr && i < idx; i++) {
+            curr = curr.next;
+        }
+        return curr;
 
     }
 }

--- a/src/day1/InsertionSort.ts
+++ b/src/day1/InsertionSort.ts
@@ -1,0 +1,3 @@
+export default function insertion_sort(arr: number[]): void {
+
+}

--- a/src/day1/LRU.ts
+++ b/src/day1/LRU.ts
@@ -1,0 +1,15 @@
+export default class LRU<K, V> {
+    private length: number;
+
+    
+
+    constructor() {
+    }
+
+    update(key: K, value: V): void {
+
+}
+    get(key: K): V | undefined {
+
+}
+}

--- a/src/day1/LRU.ts
+++ b/src/day1/LRU.ts
@@ -1,15 +1,114 @@
+type Node<T> = {
+    value: T,
+    next?: Node<T>,
+    prev?: Node<T>,
+}
+
+function createNode<V>(value: V): Node<V> {
+    return {value};
+}
 export default class LRU<K, V> {
     private length: number;
-
+    private head?: Node<V>;
+    private tail?: Node<V>;
     
+    private lookup: Map<K, Node<V>>;
+    private reverseLookup: Map<Node<V>, K>;
 
-    constructor() {
+    constructor(private capacity: number = 10) {
+        this.length = 0;
+        this.head = this.tail = undefined;
+        this.lookup = new Map<K, Node<V>>();
+        this.reverseLookup = new Map<Node<V>, K>();
     }
 
     update(key: K, value: V): void {
+        // does it exist?
+        // if it doesn't, we need to insert
+        //      - check capacity and evict if over
+        //  if it does, we need to update to front of list and update the value
 
-}
+        let node = this.lookup.get(key);
+        if (!node) {
+            node = createNode(value);
+            this.length++;
+            this.prepend(node);
+            this.trimCache();
+
+            this.lookup.set(key, node);
+            this.reverseLookup.set(node, key);
+        } else {
+            this.detach(node);
+            this.prepend(node);
+            node.value = value;
+        }
+
+    }
+
     get(key: K): V | undefined {
+        // check the cache for existence
+        const node = this.lookup.get(key);
+        if (!node) {
+            return undefined;
+        }
+            
+        // update the value we found and move it to the front
+        this.detach(node);
+        this.prepend(node);
+    
+        // return out the value found (or undefined if not exist)
+        return node.value;
+    }
 
-}
+    private detach(node: Node<V>) {
+        if (node.prev) {
+            node.prev.next = node.next;
+        }
+        
+        if (node.next) {
+            node.next.prev = node.prev;
+        }
+
+        if (this.length === 1) {
+            this.tail = this.head = undefined;
+        }
+
+        if (this.head === node) {
+            this.head = this.head.next;
+        }
+
+        if (this.tail === node) {
+            this.tail = this.tail.prev;
+        }
+
+        node.next = undefined;
+        node.prev = undefined;
+    }
+
+    private prepend(node: Node<V>) {
+        if (!this.head) {
+            this.head = this.tail = node;
+            return;
+        }
+
+        node.next = this.head;
+        this.head.prev = node;
+
+        this.head = node;
+    }
+
+    private trimCache(): void {
+        if (this.length <= this.capacity) {
+            return;
+        }
+
+        const tail = this.tail as Node<V>;
+        this.detach(this.tail as Node<V>);
+
+        const key = this.reverseLookup.get(tail) as K;
+        this.lookup.delete(key);
+        this.reverseLookup.delete(tail);
+        this.length--;
+    }
+
 }

--- a/src/day1/LRU.ts
+++ b/src/day1/LRU.ts
@@ -42,7 +42,6 @@ export default class LRU<K, V> {
             this.prepend(node);
             node.value = value;
         }
-
     }
 
     get(key: K): V | undefined {

--- a/src/day1/LinearSearchList.ts
+++ b/src/day1/LinearSearchList.ts
@@ -1,0 +1,3 @@
+export default function linear_search(haystack: number[], needle: number): boolean {
+
+}

--- a/src/day1/LinearSearchList.ts
+++ b/src/day1/LinearSearchList.ts
@@ -1,3 +1,8 @@
 export default function linear_search(haystack: number[], needle: number): boolean {
-
+  for (let i = 0; i < haystack.length; i++) {
+    if (haystack[i] === needle) {
+      return true;
+    } 
+  }
+  return false;
 }

--- a/src/day1/Map.ts
+++ b/src/day1/Map.ts
@@ -1,0 +1,21 @@
+export default class Map<T extends (string | number), V> {
+    
+
+    
+
+    constructor() {
+    }
+
+    get(key: T): V | undefined {
+
+}
+    set(key: T, value: V): void {
+
+}
+    delete(key: T): V | undefined {
+
+}
+    size(): number {
+
+}
+}

--- a/src/day1/MazeSolver.ts
+++ b/src/day1/MazeSolver.ts
@@ -1,0 +1,3 @@
+export default function solve(maze: string[], wall: string, start: Point, end: Point): Point[] {
+
+}

--- a/src/day1/MazeSolver.ts
+++ b/src/day1/MazeSolver.ts
@@ -30,6 +30,7 @@ function walk(maze: string[], wall: string, curr: Point, end: Point, seen: boole
     return false;
   }
 
+  // 2. Recursion:
   // pre
   seen[curr.y][curr.x] = true;
   path.push(curr);

--- a/src/day1/MazeSolver.ts
+++ b/src/day1/MazeSolver.ts
@@ -1,3 +1,66 @@
+const dir = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+function walk(maze: string[], wall: string, curr: Point, end: Point, seen: boolean[][], path: Point[]): boolean {
+
+  // 1. Base case:
+  // off the map
+  if (curr.x < 0 || curr.x >= maze[0].length ||
+      curr.y < 0 || curr.y >= maze.length) {
+        return false;
+  }
+
+  // on a wall
+  if (maze[curr.y][curr.x] === wall) {
+    return false;
+  }
+  
+  // at the end
+  if (curr.x === end.x && curr.y === end.y) {
+    path.push(end);
+    return true;
+  }
+
+  // visted
+  if (seen[curr.y][curr.x]) {
+    return false;
+  }
+
+  // pre
+  seen[curr.y][curr.x] = true;
+  path.push(curr);
+
+  // recurse
+  for (let i = 0; i < dir.length; i++) {
+    const [x, y] = dir[i];
+    if (walk(maze, wall, {
+      x: curr.x + x,
+      y: curr.y + y,
+    }, end, seen, path)) {
+      return true;
+    }
+  }
+
+  //post
+  path.pop();
+
+  return false;
+}
+
 export default function solve(maze: string[], wall: string, start: Point, end: Point): Point[] {
+  const seen: boolean[][] = [];
+  const path: Point[] = [];
+
+  for (let i = 0; i < maze.length; i++) {
+    seen.push(new Array(maze[i].length).fill(false));
+  }
+
+  walk(maze, wall, start, end, seen, path);
+
+  return path;
 
 }

--- a/src/day1/MergeSort.ts
+++ b/src/day1/MergeSort.ts
@@ -1,0 +1,3 @@
+export default function merge_sort(arr: number[]): void {
+
+}

--- a/src/day1/MinHeap.ts
+++ b/src/day1/MinHeap.ts
@@ -1,0 +1,15 @@
+export default class MinHeap {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    insert(value: number): void {
+
+}
+    delete(): number {
+
+}
+}

--- a/src/day1/MinHeap.ts
+++ b/src/day1/MinHeap.ts
@@ -1,15 +1,83 @@
 export default class MinHeap {
     public length: number;
-
-    
+    private data: number[];    
 
     constructor() {
+        this.data = [];
+        this.length = 0;
     }
 
     insert(value: number): void {
+        this.data[this.length] = value;
+        this.heapifyUp(this.length);
+        this.length++;
+    }
 
-}
     delete(): number {
+        if (this.length === 0) {
+            return -1;
+        }
 
-}
+        const out = this.data[0];
+        this.length--;
+
+        if (this.length === 0) {
+            this.data = [];
+            return out;
+        }
+
+        this.data[0] - this.data[this.length];
+        this.heapifyDown(0);
+        return out;
+    }
+
+    private heapifyDown(idx:number): void {
+        const lIdx = this.leftChild(idx);
+        const rIdx = this.rightChild(idx);
+
+        if (idx >= this.length || lIdx >= this.length) {
+            return;
+        }
+
+        const lV = this.data[lIdx];
+        const rV = this.data[rIdx];
+        const v = this.data[idx];
+
+        if (lV > rV && v > rV) {
+            this.data[idx] = rV;
+            this.data[rIdx] = v;
+            this.heapifyDown(rIdx);
+        } else if (rV > lV && v > lV) {
+            this.data[idx] = lV;
+            this.data[lIdx] = v;
+            this.heapifyDown(lIdx);
+        }
+    }
+
+    private heapifyUp(idx: number): void {
+        if (idx === 0) {
+            return;
+        }
+
+        const p = this.parent(idx);
+        const parentV = this.data[p];
+        const v = this.data[idx];
+
+        if (parentV > v) {
+            this.data[idx] = parentV;
+            this.data[p] = v;
+            this.heapifyUp(p);
+        }
+    }
+
+    private parent(idx: number): number {
+        return Math.floor((idx - 1) / 2);
+    }
+
+    private leftChild(idx: number): number {
+        return idx * 2 + 1;
+    }
+    private rightChild(idx: number): number {
+        return idx * 2 + 2;
+    }
 }

--- a/src/day1/PrimsList.ts
+++ b/src/day1/PrimsList.ts
@@ -1,0 +1,3 @@
+export default function prims(list: WeightedAdjacencyList): WeightedAdjacencyList | null {
+
+}

--- a/src/day1/Queue.ts
+++ b/src/day1/Queue.ts
@@ -1,0 +1,18 @@
+export default class Queue<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    enqueue(item: T): void {
+
+}
+    deque(): T | undefined {
+
+}
+    peek(): T | undefined {
+
+}
+}

--- a/src/day1/Queue.ts
+++ b/src/day1/Queue.ts
@@ -1,18 +1,54 @@
+type Node<T> = {
+    value: T,
+    next?: Node<T>,
+}
+
 export default class Queue<T> {
     public length: number;
-
-    
+    private head?: Node<T>;
+    private tail?: Node<T>;    
 
     constructor() {
+        this.head = this.tail = undefined;
+        this.length = 0;
     }
 
     enqueue(item: T): void {
+        // if (this.length === 0) {
+        // if(!this.head)
+        const node = {value: item} as Node<T>;
+        this.length++;
 
-}
+        if (!this.tail || (!this.head)) {
+            this.tail = this.head = {value: item} as Node<T>;
+        }        
+
+        this.tail.next = node;
+        this.tail = node;
+    }
+    
     deque(): T | undefined {
+        if (!this.head) {
+            return undefined;
+        }
 
-}
+        this.length--;
+
+        const head = this.head;
+        this.head = this.head.next;
+
+        // free (optional in js/ts)
+        head.next = undefined;
+
+        // tail?
+        if (this.length === 0) {
+            this.tail = undefined;
+        }
+
+        return head.value;
+    }
+
     peek(): T | undefined {
-
-}
+        return this.head?.value;
+    }
 }

--- a/src/day1/QuickSort.ts
+++ b/src/day1/QuickSort.ts
@@ -1,0 +1,3 @@
+export default function quick_sort(arr: number[]): void {
+
+}

--- a/src/day1/QuickSort.ts
+++ b/src/day1/QuickSort.ts
@@ -1,3 +1,35 @@
-export default function quick_sort(arr: number[]): void {
+function qs(arr: number[], lo: number, hi: number): void {
+  if (lo >= hi) {
+    return;
+  }
 
+  const pivotIdx = partition(arr, lo, hi);
+
+  qs(arr, lo, pivotIdx - 1);
+  qs(arr, pivotIdx + 1, hi);
+}
+
+function partition(arr: number[], lo: number, hi: number): number {
+  const pivot = arr[hi];
+
+  let idx = lo - 1;
+
+  for (let i = lo; i < hi; i++) {
+    if (arr[i] <= pivot) {
+      idx++;
+      const tmp = arr[i];
+      arr[i] = arr[idx];
+      arr[idx] = tmp;
+    }
+  }
+
+  idx++;
+  arr[hi] = arr[idx];
+  arr[idx] = pivot;
+
+  return idx;
+}
+
+export default function quick_sort(arr: number[]): void {
+  qs(arr, 0, arr.length - 1);
 }

--- a/src/day1/SinglyLinkedList.ts
+++ b/src/day1/SinglyLinkedList.ts
@@ -1,0 +1,27 @@
+export default class SinglyLinkedList<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    prepend(item: T): void {
+
+}
+    insertAt(item: T, idx: number): void {
+
+}
+    append(item: T): void {
+
+}
+    remove(item: T): T | undefined {
+
+}
+    get(idx: number): T | undefined {
+
+}
+    removeAt(idx: number): T | undefined {
+
+}
+}

--- a/src/day1/Stack.ts
+++ b/src/day1/Stack.ts
@@ -1,0 +1,18 @@
+export default class Stack<T> {
+    public length: number;
+
+    
+
+    constructor() {
+    }
+
+    push(item: T): void {
+
+}
+    pop(): T | undefined {
+
+}
+    peek(): T | undefined {
+
+}
+}

--- a/src/day1/Stack.ts
+++ b/src/day1/Stack.ts
@@ -1,18 +1,47 @@
+type Node<T> = {
+    value: T,
+    prev?: Node<T>,
+}
+
 export default class Stack<T> {
     public length: number;
-
-    
+    private head?: Node<T>;   
 
     constructor() {
+        this.head = undefined;
+        this.length = 0;
     }
 
     push(item: T): void {
+        const node = {value : item} as Node<T>;
 
-}
+        this.length++;
+        if (!this.head) {
+            this.head = node;
+            return;
+        }
+
+        node.prev = this.head;
+        this.head = node;
+        
+    }
     pop(): T | undefined {
+        // Not doing `this.length--` in case length is zero
+        this.length = Math.max(0, this.length - 1);
+        if (this.length === 0) {
+            const head = this.head;
+            this.head = undefined;
+            return head?.value;
+        }
 
-}
+        const head = this.head as Node<T>;
+        this.head = head.prev;
+
+        // free here for C++ etc.
+
+        return head.value;
+    }
     peek(): T | undefined {
-
-}
+        return this.head?.value;
+    }
 }

--- a/src/day1/Trie.ts
+++ b/src/day1/Trie.ts
@@ -1,0 +1,18 @@
+export default class Trie {
+    
+
+    
+
+    constructor() {
+    }
+
+    insert(item: string): void {
+
+}
+    delete(item: string): void {
+
+}
+    find(partial: string): string[] {
+
+}
+}

--- a/src/day1/TwoCrystalBalls.ts
+++ b/src/day1/TwoCrystalBalls.ts
@@ -1,0 +1,3 @@
+export default function two_crystal_balls(breaks: boolean[]): number {
+
+}

--- a/src/day1/TwoCrystalBalls.ts
+++ b/src/day1/TwoCrystalBalls.ts
@@ -3,7 +3,7 @@ export default function two_crystal_balls(breaks: boolean[]): number {
   let low: number = 0;
   let high: number = breaks.length;
 
-  for (let i = 1; i <= Math.sqrt(high); i ++) {
+  for (let i = 1; i <= Math.floor(Math.sqrt(high)); i ++) {
     if (breaks[i * i] === true) {
       high = i * i;
       break;

--- a/src/day1/TwoCrystalBalls.ts
+++ b/src/day1/TwoCrystalBalls.ts
@@ -1,3 +1,21 @@
 export default function two_crystal_balls(breaks: boolean[]): number {
 
+  let low: number = 0;
+  let high: number = breaks.length;
+
+  for (let i = 1; i <= Math.sqrt(high); i ++) {
+    if (breaks[i * i] === true) {
+      high = i * i;
+      break;
+    } 
+    low = i * i;
+  }
+
+  for (let j = low; j < high; j++) {
+    if (breaks[j] === true) {
+      return j;
+    }
+  }
+
+  return -1;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "baseUrl": "src",
         "paths": {
             "@code/*": [
-                "day4/*"
+                "day1/*"
             ]
         }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.5.tgz"
   integrity sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3":
   version "7.18.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz"
   integrity sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==
@@ -532,18 +532,18 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.13"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz"
-  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.13"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz"
+  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -591,39 +591,6 @@
   dependencies:
     source-map-support "^0.5.21"
     tslib "^2.5.0"
-
-"@swc/core-linux-x64-gnu@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.80.tgz"
-  integrity sha512-+2e5oni1vOrLIjM5Q2/GIzK/uS2YEtuJqnjPvCK8SciRJsSl8OgVsRvyCDbmKeZNtJ2Q+o/O2AQ2w1qpAJG6jg==
-
-"@swc/core-linux-x64-musl@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.80.tgz"
-  integrity sha512-8OK9IlI1zpWOm7vIp1iXmZSEzLAwFpqhsGSEhxPavpOx2m54kLFdPcw/Uv3n461f6TCtszIxkGq1kSqBUdfUBA==
-
-"@swc/core@>= 1.3", "@swc/core@>=1.2.50":
-  version "1.3.80"
-  resolved "https://registry.npmjs.org/@swc/core/-/core-1.3.80.tgz"
-  integrity sha512-yX2xV5I/lYswHHR+44TPvzBgq3/Y8N1YWpTQADYuvSiX3Jxyvemk5Jpx3rRtigYb8WBkWAAf2i5d5ZJ2M7hhgw==
-  dependencies:
-    "@swc/types" "^0.1.3"
-  optionalDependencies:
-    "@swc/core-darwin-arm64" "1.3.80"
-    "@swc/core-darwin-x64" "1.3.80"
-    "@swc/core-linux-arm-gnueabihf" "1.3.80"
-    "@swc/core-linux-arm64-gnu" "1.3.80"
-    "@swc/core-linux-arm64-musl" "1.3.80"
-    "@swc/core-linux-x64-gnu" "1.3.80"
-    "@swc/core-linux-x64-musl" "1.3.80"
-    "@swc/core-win32-arm64-msvc" "1.3.80"
-    "@swc/core-win32-ia32-msvc" "1.3.80"
-    "@swc/core-win32-x64-msvc" "1.3.80"
-
-"@swc/types@^0.1.3":
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/@swc/types/-/types-0.1.4.tgz"
-  integrity sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -800,7 +767,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-babel-jest@^28.0.0, babel-jest@^28.1.1:
+babel-jest@^28.1.1:
   version "28.1.1"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.1.tgz"
   integrity sha512-MEt0263viUdAkTq5D7upHPNxvt4n9uLUGa6pPz3WviNBMtOmStb1lIXS3QobnoqM+qnH+vr4EKlvhe8QcmxIYw==
@@ -880,7 +847,7 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.20.2, "browserslist@>= 4.21.0":
+browserslist@^4.20.2:
   version "4.21.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz"
   integrity sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==
@@ -994,15 +961,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@^2.0.19:
   version "2.0.20"
@@ -1140,7 +1107,7 @@ expect@^28.1.1:
     jest-message-util "^28.1.1"
     jest-util "^28.1.1"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1171,6 +1138,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1553,7 +1525,7 @@ jest-resolve-dependencies@^28.1.1:
     jest-regex-util "^28.0.2"
     jest-snapshot "^28.1.1"
 
-jest-resolve@*, jest-resolve@^28.1.1:
+jest-resolve@^28.1.1:
   version "28.1.1"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.1.tgz"
   integrity sha512-/d1UbyUkf9nvsgdBildLe6LAD4DalgkgZcKd0nZ8XUGPyA/7fsnaQIlKVnDiuUXv/IeZhPEDrRJubVSulxrShA==
@@ -1699,7 +1671,7 @@ jest-worker@^28.1.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^28.0.0, jest@^28.1.1:
+jest@^28.1.1:
   version "28.1.1"
   resolved "https://registry.npmjs.org/jest/-/jest-28.1.1.tgz"
   integrity sha512-qw9YHBnjt6TCbIDMPMpJZqf9E12rh6869iZaN08/vpOGgHJSAaLLUn6H8W3IAEuy34Ls3rct064mZLETkxJ2XA==
@@ -1778,7 +1750,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1, make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -2008,24 +1980,17 @@ safe-buffer@~5.1.1:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+semver@7.x, semver@^7.3.5:
+  version "7.3.7"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.x:
-  version "7.3.7"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2054,18 +2019,18 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-support@^0.5.21:
-  version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -2218,7 +2183,7 @@ ts-jest@^28.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-node@^10.8.1, ts-node@>=9.0.0:
+ts-node@^10.8.1:
   version "10.8.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz"
   integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
@@ -2266,7 +2231,7 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.7.4, "typescript@>= 4.3", typescript@>=2.7, typescript@>=4.3:
+typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large drop of new algorithm/data-structure implementations plus config changes that redirect the `@code/*` path; several new modules are stubs or likely buggy, so test failures/behavior mismatches are plausible.
> 
> **Overview**
> Repoints the `@code/*` TypeScript/Jest path alias from `src/day4`/`src/day2` to `src/day1`, making tests and imports resolve to the new Day 1 implementations.
> 
> Adds a broad set of Day 1 DSA modules under `src/day1` (searching, sorting, trees, graphs, cache, heap, maze solving), and updates `ligma.config.js` and the `test` script to include the expanded suite. Several new files are currently placeholder stubs (e.g., `InsertionSort`, `MergeSort`, `PrimsList`, `ArrayList`, `SinglyLinkedList`, `Map`, `Trie`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27154d1e2dc8e76595081e126677cfc18e3a9c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->